### PR TITLE
partition-based routing

### DIFF
--- a/c_code/init_i.c
+++ b/c_code/init_i.c
@@ -72,9 +72,19 @@ uint i_init (void)
   i_pkt_queue.tail = 0;
 
   // initialize packet keys
+  // allocate memory for backprop keys (one per partition)
+  if ((i_bkpKey = ((uint *)
+         spin1_malloc (icfg.partitions * sizeof(uint)))) == NULL
+     )
+  {
+    return (SPINN_MEM_UNAVAIL);
+  }
+
   //NOTE: colour is initialized to 0.
   fwdKey = rt[FWD] | SPINN_PHASE_KEY(SPINN_FORWARD);
-  bkpKey = rt[BKP] | SPINN_PHASE_KEY(SPINN_BACKPROP);
+  for (uint p = 0; p < icfg.partitions; p++) {
+	  i_bkpKey[p] = rt[BKPI + p] | SPINN_PHASE_KEY (SPINN_BACKPROP);
+  }
 
   // if input or output group initialize event input/target index
   if (icfg.input_grp || icfg.output_grp)

--- a/c_code/init_t.c
+++ b/c_code/init_t.c
@@ -273,8 +273,18 @@ uint t_init (void)
   }
 
   // initialise packet keys
+  // allocate memory for forward keys (one per partition)
+  if ((t_fwdKey = ((uint *)
+         spin1_malloc (tcfg.partitions * sizeof(uint)))) == NULL
+     )
+  {
+    return (SPINN_MEM_UNAVAIL);
+  }
+
   //NOTE: colour is initialised to 0
-  fwdKey = rt[FWD] | SPINN_PHASE_KEY (SPINN_FORWARD);
+  for (uint p = 0; p < tcfg.partitions; p++) {
+	  t_fwdKey[p] = rt[FWDT + p] | SPINN_PHASE_KEY (SPINN_FORWARD);
+  }
   bkpKey = rt[BKP] | SPINN_PHASE_KEY (SPINN_BACKPROP);
 
   // if input or output group initialize event input/target index

--- a/c_code/input.c
+++ b/c_code/input.c
@@ -115,6 +115,8 @@ uint             if_thrds_pend;     // sync. semaphore: proc & stop
 long_delta_t   * ib_init_delta;     // initial delta value for every tick
 scoreboard_t     ib_done;           // current tick delta computation done
 
+uint           * i_bkpKey;          // i cores have one bkpKey per partition
+
 // history arrays
 long_net_t     * i_net_history;   //sdram pointer where to store input history
 // ------------------------------------------------------------------------
@@ -180,7 +182,7 @@ uint init ()
   // initialise core-specific configuration from SDRAM
   spin1_memcpy (&icfg, dt, sizeof (i_conf_t));
 
-  // inputs iff this core receives inputs from examples file
+  // inputs if this core receives inputs from examples file
   if (icfg.input_grp)
   {
 	  it = (activation_t *) data_specification_get_region

--- a/c_code/mlp_externs.h
+++ b/c_code/mlp_externs.h
@@ -116,6 +116,8 @@ extern scoreboard_t     ib_done;       // current tick delta computation done
 extern long_net_t     * i_last_integr_net;   //last integrator output value
 extern long_delta_t   * i_last_integr_delta; //last integrator delta value
 
+extern uint           * i_bkpKey;      // i cores have one bkpKey per partition
+
 // history arrays
 extern long_net_t      * i_net_history; //sdram pointer where to store input history
 // ------------------------------------------------------------------------
@@ -169,6 +171,8 @@ extern activation_t     t_max_output;      // highest output value
 extern activation_t     t_max_target;      // highest target value
 extern long_deriv_t   * t_output_deriv;
 extern delta_t        * t_deltas;
+
+extern uint           * t_fwdKey;      // t cores have one fwdKey per partition
 
 // history arrays
 extern net_t          * t_net_history;

--- a/c_code/mlp_types.h
+++ b/c_code/mlp_types.h
@@ -16,12 +16,16 @@ enum MLPRegions {
 	ROUTING
 };
 
+// t cores can have more than one FWD key (due to partitions)
+// i cores can have more than one BKP key (due to partitions)
 enum MLPKeys {
-	FWD,
-	BKP,
-	FDS,
-	STP,
-	LDS
+	FWD = 0,
+	BKP = 1,
+	FDS = 2,
+	STP = 3,
+	LDS = 4,
+	FWDT = 5,
+	BKPI = 5
 };
 
 typedef short     short_activ_t;
@@ -241,6 +245,7 @@ typedef struct i_conf                // input core configuration
   uchar         output_grp;          // is this an OUTPUT group?
   uchar         input_grp;           // is this an INPUT group?
   uint          num_units;           // this core's number of units
+  uint          partitions;          // this groups's number of partitions
   uint          num_in_procs;        // number of input (net) comp procedures
   uint          procs_list[SPINN_NUM_IN_PROCS];
   uchar         in_integr_en;        // input integrator in use
@@ -266,6 +271,7 @@ typedef struct t_conf                  // threshold core configuration
   uchar         output_grp;            // is this an OUTPUT group?
   uchar         input_grp;             // is this an INPUT group?
   uint          num_units;             // this core's number of units
+  uint          partitions;            // this group's number of partitions
   scoreboard_t  fwd_sync_expected;     // all expected FORWARD sync packets
   scoreboard_t  bkp_sync_expected;     // all expected BACKPROP sync packets
   uchar         write_out;             // write outputs (send to host)?

--- a/c_code/process_i.c
+++ b/c_code/process_i.c
@@ -202,7 +202,7 @@ void i_backprop_packet (uint key, uint payload)
 #endif
 
   // incorporate delta index to the packet key and send,
-  while (!spin1_send_mc_packet ((bkpKey | inx), delta, WITH_PAYLOAD));
+  while (!spin1_send_mc_packet ((i_bkpKey[inx >> SPINN_BLOCK_SHIFT] | inx), delta, WITH_PAYLOAD));
 
 #ifdef DEBUG
   pkt_sent++;

--- a/c_code/process_t.c
+++ b/c_code/process_t.c
@@ -70,7 +70,7 @@ void tf_process (uint null0, uint null1)
 #endif
 
     // incorporate output index into packet key and send to next stage,
-    while (!spin1_send_mc_packet ((fwdKey | inx),
+    while (!spin1_send_mc_packet ((t_fwdKey[inx >> SPINN_BLOCK_SHIFT] | inx),
                                    (uint) activation,
                                    WITH_PAYLOAD
                                  )
@@ -756,7 +756,7 @@ void t_init_outputs (uint null0, uint null1)
 #endif
 
     // and send unit output to weight cores
-    while (!spin1_send_mc_packet ((fwdKey | i),
+    while (!spin1_send_mc_packet ((t_fwdKey[i >> SPINN_BLOCK_SHIFT] | i),
                                    (uint) t_outputs[i],
                                    WITH_PAYLOAD
                                  )

--- a/c_code/threshold.c
+++ b/c_code/threshold.c
@@ -167,6 +167,8 @@ activation_t     t_max_target;      // highest target value
 long_deriv_t   * t_output_deriv;    // derivative of the output value
 delta_t        * t_deltas;
 
+uint           * t_fwdKey;          // t cores have one fwdKey per partition
+
 // history arrays
 net_t          * t_net_history;
 activation_t   * t_output_history;

--- a/spinn_pdp2/mlp_network.py
+++ b/spinn_pdp2/mlp_network.py
@@ -499,7 +499,7 @@ class MLPNetwork():
 
                 # create forward t to w (multicast) links
                 g.add_machine_edge_instance (MachineEdge (_frmg.t_vertex, w),
-                                             _frmg.t_vertex.fwd_link)
+                                             _frmg.t_vertex.fwd_link[w.row_blk])
 
                 # create backprop w to s links
                 g.add_machine_edge_instance (MachineEdge (w, _frmg.s_vertex),
@@ -507,7 +507,7 @@ class MLPNetwork():
 
                 # create backprop i to w (multicast) links
                 g.add_machine_edge_instance (MachineEdge (grp.i_vertex, w),
-                                             grp.i_vertex.bkp_link)
+                                             grp.i_vertex.bkp_link[w.col_blk])
 
                 # create forward synchronisation w to t links
                 g.add_machine_edge_instance (MachineEdge (w, _frmg.t_vertex),

--- a/spinn_pdp2/weight_vertex.py
+++ b/spinn_pdp2/weight_vertex.py
@@ -178,6 +178,14 @@ class WeightVertex(
         return self._from_group
 
     @property
+    def row_blk (self):
+        return self._row_blk
+
+    @property
+    def col_blk (self):
+        return self._col_blk
+
+    @property
     def fwd_link (self):
         return self._fwd_link
 


### PR DESCRIPTION
This pull request implements the changes needed to route packets based on group partitions instead of groups.

Currently, forward packets from t cores to w cores are sent with a 'group' key. If the group has been partitioned due to its size, all packets go to all w cores unnecessarily. The changes introduced here use 'group-partition' keys to route packets, thus sending each t core packet only to the w cores that require it.

Equivalent changes are done for backprop packets from i cores to w cores.