### PR TITLE
Stop passing config values through the simulator

### DIFF
--- a/spinn_pdp2/input_vertex.py
+++ b/spinn_pdp2/input_vertex.py
@@ -32,7 +32,7 @@ from spinn_front_end_common.utilities.constants \
 
 from spinnaker_graph_front_end.utilities import SimulatorVertex
 from spinnaker_graph_front_end.utilities.data_utils \
-    import generate_steps_system_data_region
+    import generate_system_data_region
 
 from spinn_pdp2.mlp_types import MLPRegions, MLPConstants
 
@@ -213,7 +213,7 @@ class InputVertex(
             reverse_iptags):
 
         # Generate the system data region for simulation.c requirements
-        generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)
+        generate_system_data_region(spec, MLPRegions.SYSTEM.value, self)
 
         # Reserve and write the network configuration region
         spec.reserve_memory_region (MLPRegions.NETWORK.value,

--- a/spinn_pdp2/input_vertex.py
+++ b/spinn_pdp2/input_vertex.py
@@ -210,7 +210,7 @@ class InputVertex(
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(
             self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags, machine_time_step, time_scale_factor):
+            reverse_iptags):
 
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)

--- a/spinn_pdp2/sum_vertex.py
+++ b/spinn_pdp2/sum_vertex.py
@@ -236,7 +236,7 @@ class SumVertex(
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(
             self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags, machine_time_step, time_scale_factor):
+            reverse_iptags):
 
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)

--- a/spinn_pdp2/sum_vertex.py
+++ b/spinn_pdp2/sum_vertex.py
@@ -35,7 +35,7 @@ from spinn_front_end_common.utilities.constants \
 
 from spinnaker_graph_front_end.utilities import SimulatorVertex
 from spinnaker_graph_front_end.utilities.data_utils \
-    import generate_steps_system_data_region
+    import generate_system_data_region
 
 from spinn_pdp2.mlp_types import MLPRegions, MLPConstants
 
@@ -239,7 +239,7 @@ class SumVertex(
             reverse_iptags):
 
         # Generate the system data region for simulation.c requirements
-        generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)
+        generate_system_data_region(spec, MLPRegions.SYSTEM.value, self)
 
         # Reserve and write the network configuration region
         spec.reserve_memory_region (MLPRegions.NETWORK.value,

--- a/spinn_pdp2/threshold_vertex.py
+++ b/spinn_pdp2/threshold_vertex.py
@@ -385,7 +385,7 @@ class ThresholdVertex(
                additional_arguments=["data_n_steps"])
     def generate_machine_data_specification(
             self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags, machine_time_step, time_scale_factor, data_n_steps):
+            reverse_iptags, data_n_steps):
 
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)

--- a/spinn_pdp2/threshold_vertex.py
+++ b/spinn_pdp2/threshold_vertex.py
@@ -38,7 +38,7 @@ from spinn_front_end_common.utilities.helpful_functions import (
 
 from spinnaker_graph_front_end.utilities import SimulatorVertex
 from spinnaker_graph_front_end.utilities.data_utils \
-    import generate_steps_system_data_region
+    import generate_system_data_region
 
 from spinn_pdp2.mlp_types import MLPConstants, MLPRegions, \
     MLPVarSizeRecordings, MLPConstSizeRecordings, MLPExtraRecordings
@@ -388,7 +388,7 @@ class ThresholdVertex(
             reverse_iptags, data_n_steps):
 
         # Generate the system data region for simulation.c requirements
-        generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)
+        generate_system_data_region(spec, MLPRegions.SYSTEM.value, self)
 
         # reserve and write the network configuration region
         spec.reserve_memory_region (MLPRegions.NETWORK.value,

--- a/spinn_pdp2/weight_vertex.py
+++ b/spinn_pdp2/weight_vertex.py
@@ -277,7 +277,7 @@ class WeightVertex(
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(
             self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags, machine_time_step, time_scale_factor):
+            reverse_iptags):
 
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)

--- a/spinn_pdp2/weight_vertex.py
+++ b/spinn_pdp2/weight_vertex.py
@@ -32,7 +32,7 @@ from spinn_front_end_common.utilities.constants \
 
 from spinnaker_graph_front_end.utilities import SimulatorVertex
 from spinnaker_graph_front_end.utilities.data_utils \
-    import generate_steps_system_data_region
+    import generate_system_data_region
 
 from spinn_pdp2.mlp_types import MLPRegions, MLPConstants
 
@@ -280,7 +280,7 @@ class WeightVertex(
             reverse_iptags):
 
         # Generate the system data region for simulation.c requirements
-        generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)
+        generate_system_data_region(spec, MLPRegions.SYSTEM.value, self)
 
         # Reserve and write the network configuration region
         spec.reserve_memory_region (MLPRegions.NETWORK.value,

--- a/unittests/test_cfg_checker.py
+++ b/unittests/test_cfg_checker.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from spinn_utilities.config_holder import run_config_checks
+from spinnaker_graph_front_end.config_setup import reset_configs
+
+
+class TestCfgChecker(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        reset_configs()
+
+    def test_cfg_check(self):
+        unittests = os.path.dirname(__file__)
+        parent = os.path.dirname(unittests)
+        spinn_pdp2 = os.path.join(parent, "spinn_pdp2")
+        integration_tests = os.path.join(parent, "integration_tests")
+        examples = os.path.join(parent, "examples")
+        repeaters = [
+            "application_to_machine_graph_algorithms",
+            "machine_graph_to_machine_algorithms",
+            "machine_graph_to_virtual_machine_algorithms",
+            "loading_algorithms"]
+        run_config_checks(
+            directories=[spinn_pdp2, integration_tests, unittests, examples],
+            repeaters=repeaters)


### PR DESCRIPTION
This keeps things in line with the changes due to 
https://github.com/SpiNNakerManchester/PyNN8Examples/pull/65
(MUST be merged at the same time!)

generate_machine_data_specification API dropped two params PDP2 did not want anyway

generate_steps_system_data_region no longer needed as a wrapper around generate_system_data_region 

TestCfgChecker is future proofing. If PDP2 ever adds a cgf file or a get_config... method these will be automatically checked.