### PR TITLE
test and support python 3.10 instead of 3.6

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,10 @@ setup(
         "Operating System :: MacOS",
 
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     packages=packages,
     package_data=package_data,


### PR DESCRIPTION
Python 3.6 has reach end if life.

We are finding more and more of the tools we depend on are adding features that do not work in python 3.6

Python 10 is now the default python so should be tested.