### PR TITLE
turn off xml validation

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -77,11 +77,12 @@ jobs:
       if: matrix.python-version == 3.8
       uses: ./support/actions/check-copyrights
 
-    - name: Validate all XML
-      if: matrix.python-version == 3.8
-      uses: ./support/actions/validate-xml
-      with:
-        base-path: spinn_pdp2
+    # Currently no xml files so no need to validate
+    #- name: Validate all XML
+    #  if: matrix.python-version == 3.8
+    #  uses: ./support/actions/validate-xml
+    #  with:
+    #    base-path: spinn_pdp2
 
     #- name: Build documentation with sphinx (3.8 only)
     #  uses: ./support/actions/sphinx


### PR DESCRIPTION
With the removal of the Algorithm xml files we have no xml files to validate.

So currently no need for that github stage.

Left commented out so easy to reinstate if required.
(Assuming of course their server issues are fixed)