### PR TITLE
Initial support for online learning (weight updates after every example)

### DIFF
--- a/spinn_pdp2/mlp_network.py
+++ b/spinn_pdp2/mlp_network.py
@@ -1076,6 +1076,7 @@ class MLPNetwork():
 
     def train (self,
                update_function = None,
+               num_examples = None,
                num_updates = None
               ):
         """ do one stage in train mode
@@ -1089,7 +1090,7 @@ class MLPNetwork():
         self._stg_epochs = num_updates
 
         # sort the number of examples at configuration time
-        self._stg_examples = None
+        self._stg_examples = num_examples
 
         # always reset the example index at the start of training stage 
         self._stg_reset = True


### PR DESCRIPTION
In the current implementation a training stage always runs for the complete set of examples in the training file.

This pull request makes the number of examples to run a parameter of the training stage.
