### PR TITLE
Global Data new

### DIFF
--- a/spinn_pdp2/input_vertex.py
+++ b/spinn_pdp2/input_vertex.py
@@ -27,6 +27,7 @@ from spinn_front_end_common.abstract_models import \
     AbstractRewritesDataSpecification
 from spinn_front_end_common.abstract_models.impl \
     import MachineDataSpecableVertex
+from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants \
     import SYSTEM_BYTES_REQUIREMENT
 
@@ -209,8 +210,9 @@ class InputVertex(
 
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(
-            self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags):
+            self, spec, placement, iptags, reverse_iptags):
+
+        routing_info = FecDataView.get_routing_infos()
 
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)

--- a/spinn_pdp2/mlp_network.py
+++ b/spinn_pdp2/mlp_network.py
@@ -19,7 +19,7 @@ import struct
 import spinnaker_graph_front_end as gfe
 
 from pacman.model.graphs.machine import MachineEdge
-
+from spinn_front_end_common.data import FecDataView
 from spinn_pdp2.input_vertex     import InputVertex
 from spinn_pdp2.sum_vertex       import SumVertexTree
 from spinn_pdp2.threshold_vertex import ThresholdVertex
@@ -648,7 +648,7 @@ class MLPNetwork():
                 ftv = g.t_vertex[0]
                 try:
                     rec_tick_data = ftv.read (
-                        gfe.placements().get_placement_of_vertex (ftv),
+                        FecDataView.get_placement_of_vertex(ftv),
                         gfe.buffer_manager(), MLPExtraRecordings.TICK_DATA.value
                         )
                 except Exception as err:
@@ -666,7 +666,7 @@ class MLPNetwork():
                         gtv = g.t_vertex[s]
                         try:
                             rec_outputs[g.write_blk].append (gtv.read (
-                                gfe.placements().get_placement_of_vertex (gtv),
+                                FecDataView.get_placement_of_vertex(ftv),
                                 gfe.buffer_manager(),
                                 MLPVarSizeRecordings.OUTPUTS.value)
                                 )
@@ -801,7 +801,7 @@ class MLPNetwork():
             ltv = g.t_vertex[g.subgroups - 1]
             try:
                 rec_test_results = ltv.read (
-                    gfe.placements().get_placement_of_vertex (ltv),
+                    FecDataView.get_placement_of_vertex(ftv),
                     gfe.buffer_manager(), MLPConstSizeRecordings.TEST_RESULTS.value
                     )
             except Exception as err:

--- a/spinn_pdp2/sum_vertex.py
+++ b/spinn_pdp2/sum_vertex.py
@@ -30,6 +30,7 @@ from spinn_front_end_common.abstract_models import \
     AbstractRewritesDataSpecification
 from spinn_front_end_common.abstract_models.impl \
     import MachineDataSpecableVertex
+from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants \
     import SYSTEM_BYTES_REQUIREMENT
 
@@ -235,9 +236,9 @@ class SumVertex(
 
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(
-            self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags):
+            self, spec, placement, iptags, reverse_iptags):
 
+        routing_info = FecDataView.get_routing_infos()
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)
 

--- a/spinn_pdp2/threshold_vertex.py
+++ b/spinn_pdp2/threshold_vertex.py
@@ -19,7 +19,6 @@ from data_specification.enums.data_type import DataType
 
 from pacman.model.graphs.machine.machine_vertex import MachineVertex
 from pacman.model.resources import ResourceContainer, VariableSDRAM, ConstantSDRAM
-from pacman.executor.injection_decorator import inject_items
 
 from spinn_utilities.overrides import overrides
 
@@ -27,6 +26,7 @@ from spinn_front_end_common.abstract_models import \
     AbstractRewritesDataSpecification
 from spinn_front_end_common.abstract_models.impl \
     import MachineDataSpecableVertex
+from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants \
     import SYSTEM_BYTES_REQUIREMENT, BYTES_PER_WORD
 from spinn_front_end_common.interface.buffer_management.buffer_models import (
@@ -378,14 +378,12 @@ class ThresholdVertex(
         return raw_data
 
 
-    @inject_items({
-        "data_n_steps": "DataNSteps"
-    })
-    @overrides(MachineDataSpecableVertex.generate_machine_data_specification,
-               additional_arguments=["data_n_steps"])
+    @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(
-            self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags, data_n_steps):
+            self, spec, placement, iptags, reverse_iptags):
+
+        routing_info = FecDataView.get_routing_infos()
+        data_n_steps = FecDataView.get_max_run_time_steps()
 
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)
@@ -584,6 +582,6 @@ class ThresholdVertex(
 
 
     @overrides(AbstractReceiveBuffersToHost.get_recording_region_base_address)
-    def get_recording_region_base_address(self, txrx, placement):
+    def get_recording_region_base_address(self, placement):
         return locate_memory_region_for_placement(
-            placement, MLPRegions.REC_INFO.value, txrx)
+            placement, MLPRegions.REC_INFO.value)

--- a/spinn_pdp2/weight_vertex.py
+++ b/spinn_pdp2/weight_vertex.py
@@ -27,6 +27,7 @@ from spinn_front_end_common.abstract_models import \
     AbstractRewritesDataSpecification
 from spinn_front_end_common.abstract_models.impl \
     import MachineDataSpecableVertex
+from spinn_front_end_common.data import FecDataView
 from spinn_front_end_common.utilities.constants \
     import SYSTEM_BYTES_REQUIREMENT
 
@@ -276,9 +277,9 @@ class WeightVertex(
 
     @overrides(MachineDataSpecableVertex.generate_machine_data_specification)
     def generate_machine_data_specification(
-            self, spec, placement, machine_graph, routing_info, iptags,
-            reverse_iptags):
+            self, spec, placement, iptags, reverse_iptags):
 
+        routing_info = FecDataView.get_routing_infos()
         # Generate the system data region for simulation.c requirements
         generate_steps_system_data_region(spec, MLPRegions.SYSTEM.value, self)
 


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNUtils/pull/172

Simplified summary.

Most of the data has been moved from AbstractSimulatorBase to  FecDataView

This means there is a lot less passing around of parameters and no need for injections.

Specifically for PdP2 
the signature of generate_machine_data_specification has been simplified

Extra data needed can now be obtained directly on demand 

This includes 
FecDataView.get_routing_infos()
FecDataView.get_placements()
and a semantic sugar on placements
FecDataView.get_placement_of_vertex(vertex)

